### PR TITLE
Ada, Mercury, and Tcl implementations

### DIFF
--- a/ada_fizzbuzz.adb
+++ b/ada_fizzbuzz.adb
@@ -1,0 +1,26 @@
+-- Note: GNAT complains if the unit is simply named "Ada" since that is a system
+--  unit. gnatmake silently refuses to do anything.
+
+with Ada.Strings.Bounded;
+with Ada.Text_IO;
+
+procedure Ada_FizzBuzz is
+   package IO renames Ada.Text_IO;
+
+   function FizzBuzz(N : Integer) return String is
+   begin
+      if N mod 3 = 0 and N mod 5 = 0 then
+         return "fizzbuzz";
+      elsif N mod 3 = 0 then
+         return "fizz";
+      elsif N mod 5 = 0 then
+         return "buzz";
+      else
+         return Integer'Image(N);
+      end if;
+   end FizzBuzz;
+begin
+   for I in Integer range 1 .. 100 loop
+      IO.Put_Line(FizzBuzz(I));
+   end loop;
+end Ada_FizzBuzz;

--- a/mercury.m
+++ b/mercury.m
@@ -1,0 +1,37 @@
+:- module mercury. %% Mercury requires that the module name is the same as the
+                   %% file name.
+
+:- interface.
+
+:- import_module io.
+
+:- pred main(io::di, io::uo) is det.
+
+:- implementation.
+
+:- import_module int, string, bool.
+
+:- func fizz(int) = bool.
+:- func buzz(int) = bool.
+:- func fizzbuzz(int, bool, bool) = string.
+
+
+fizz(N) = (if N mod 3 = 0 then yes else no).
+buzz(N) = (if N mod 5 = 0 then yes else no).
+
+fizzbuzz(_, yes, yes) = "fizzbuzz".
+fizzbuzz(_, yes, no)  = "fizz".
+fizzbuzz(_, no, yes)  = "buzz".
+fizzbuzz(N, no, no)   = from_int(N).
+
+:- pred print_fizzbuzz(int::in, int::in, io::di, io::uo) is det.
+print_fizzbuzz(N, Upper, !IO) :-
+    io.write_string(fizzbuzz(N, fizz(N), buzz(N)), !IO),
+       io.nl(!IO),
+          (if N < Upper
+           then print_fizzbuzz(N + 1, Upper, !IO)
+           else !:IO = !.IO).  %% Do not change the IO state. This is a no-op,
+                               %% but since `if` clauses must have an `else`, we
+                               %% need to return something.
+
+main(!IO) :- print_fizzbuzz(1, 100, !IO).

--- a/tcl.tcl
+++ b/tcl.tcl
@@ -2,7 +2,7 @@ proc fizzbuzz n {
     switch -regexp [list $n [expr {$n % 3}]] {
         {[05] 0} {list fizzbuzz}
         {[^05] 0} {list fizz}
-        {[05] [1-9]} {list buzz}
+        {[05] [12]} {list buzz}
         default {list $n}
     }
 }

--- a/tcl.tcl
+++ b/tcl.tcl
@@ -1,0 +1,12 @@
+proc fizzbuzz n {
+    switch -regexp [list $n [expr {$n % 3}]] {
+        {[05] 0} {list fizzbuzz}
+        {[^05] 0} {list fizz}
+        {[05] [1-9]} {list buzz}
+        default {list $n}
+    }
+}
+
+for {set i 0} {$i <= 100} {incr i} {
+    puts [fizzbuzz $i]
+}


### PR DESCRIPTION
Ada implementation has to be called ada_fizzbuzz.adb since a plain "ada.adb" confuses the compiler into thinking it's a system unit.