### PR TITLE
Make Crystal implementation robust

### DIFF
--- a/crystal.cr
+++ b/crystal.cr
@@ -1,1 +1,15 @@
-ruby.rb
+def fizz_buzz(num : Int)
+  if num % 15 == 0
+    puts "FizzBuzz"
+  elsif num % 3 == 0
+    puts "Fizz"
+  elsif num % 5 == 0
+    puts "Buzz"
+  else
+    puts num
+  end
+end
+
+(1..100).each do |x|
+  fizz_buzz(x)
+end


### PR DESCRIPTION
Now `fizz_buzz` receives integer only by type specification, which makes differences from Ruby.